### PR TITLE
BUG FIX: 修复多线程异常处理会导致UI线程异常报告模块卡死的问题

### DIFF
--- a/howtrader/api/rest/rest_client.py
+++ b/howtrader/api/rest/rest_client.py
@@ -196,7 +196,7 @@ class RestClient(object):
             et, ev, tb = sys.exc_info()
             self.on_error(et, ev, tb, None)
 
-    def sign(self, request: Request) -> None:
+    def sign(self, request: Request) -> Request:
         """
         This function is called before sending any request out.
         Please implement signature method here.
@@ -231,7 +231,7 @@ class RestClient(object):
         exception_value: Exception,
         tb,
         request: Optional[Request],
-    ) -> None:
+    ) -> str:
         text = "[{}]: Unhandled RestClient Error:{}\n".format(
             datetime.now().isoformat(), exception_type
         )

--- a/howtrader/event/engine.py
+++ b/howtrader/event/engine.py
@@ -1,7 +1,7 @@
 """
 Event-driven framework of vn.py framework.
 """
-
+import sys
 from collections import defaultdict
 from queue import Empty, Queue
 from threading import Thread
@@ -63,17 +63,21 @@ class EventEngine:
 
     def _process(self, event: Event) -> None:
         """
-        First ditribute event to those handlers registered listening
+        First distribute event to those handlers registered listening
         to this type.
 
-        Then distrubute event to those general handlers which listens
+        Then distribute event to those general handlers which listens
         to all types.
         """
-        if event.type in self._handlers:
-            [handler(event) for handler in self._handlers[event.type]]
+        try:
+            if event.type in self._handlers:
+                [handler(event) for handler in self._handlers[event.type]]
 
-        if self._general_handlers:
-            [handler(event) for handler in self._general_handlers]
+            if self._general_handlers:
+                [handler(event) for handler in self._general_handlers]
+        except Exception:
+            et, ev, tb = sys.exc_info()
+            sys.excepthook(et, ev, tb)
 
     def _run_timer(self) -> None:
         """

--- a/howtrader/trader/app.py
+++ b/howtrader/trader/app.py
@@ -5,7 +5,7 @@ from abc import ABC
 
 class BaseApp(ABC):
     """
-    Absstract class for app.
+    Abstract class for app.
     """
 
     app_name: str = ""           # Unique name used for creating engine and widget


### PR DESCRIPTION
- EventEngine、EmailEngine、WesocketClient等工作线程，需要在`run()` `_process()` `on_error()`函数中使用try expect捕捉所有异常，记录日志，并通过sys.excepthook通知上层应用
- UI模式下，create_qapp的时候会通过`sys.excepthook = excepthook`拦截全局异常处理函数，并弹出ExceptionDialog对话框提醒用户，但这个对话框必须运行在UI线程下，而不是原始抛出异常的工作线程，如果在工作线程下弹出对话框，则会卡死工作线程
- 修改方案：`excepthook()`不直接弹出对话框，而是通过QtPy5的信号`qapp.signal_exception.emit(msg)`发送给UI线程，UI线程收到信号后，再弹出UI对话框